### PR TITLE
Testfix

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ machine:
 dependencies:
   pre:
     - "sudo apt-get update && sudo apt-get install -y libgmp3-dev"
-    - rm -rf ~/.go_workspace
+      #- rm -rf ~/.go_workspace
 
   override:
     - go get -t -d -v ./...

--- a/circle.yml
+++ b/circle.yml
@@ -2,13 +2,17 @@ general:
   build_dir: cmd/epm
 
 machine:
+  pre:
+    - rm -rf ${GOPATH%%:*}/src/github.com/${CIRCLE_PROJECT_USERNAME}
+    - mkdir -p ${GOPATH%%:*}/src/github.com/${CIRCLE_PROJECT_USERNAME}
+    - cp -r ${HOME}/${CIRCLE_PROJECT_REPONAME} ${GOPATH%%:*}/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
+
   services:
     - docker
 
 dependencies:
   pre:
     - "sudo apt-get update && sudo apt-get install -y libgmp3-dev"
-      #- rm -rf ~/.go_workspace
 
   override:
     - go get -t -d -v ./...


### PR DESCRIPTION
this PR fixes test failure which are due to circleCI not currently go-getting the repo which it is testing. By default circleCI only clones the repo into the box's `~` dir and then it does the go get from there which means that the epm files will not be in $GOPATH... this fix required that circleCI be given an env var of GOPATH=${GOPATH%%:*} because of how it symlinks in. Although this is not [great behaviour](https://groups.google.com/forum/#!topic/golang-nuts/zHmR7z921j4), it is the reality.