### PR TITLE
epm plop config should always display

### DIFF
--- a/cmd/epm/cli.go
+++ b/cmd/epm/cli.go
@@ -48,9 +48,13 @@ func cliPlop(c *cli.Context) {
 	toPlop := c.Args().First()
 	switch toPlop {
 	case "genesis":
-		ifExit(utils.Copy(path.Join(utils.Blockchains, "thelonious", "genesis.json"), "genesis.json"))
+		b, err := ioutil.ReadFile(path.Join(utils.Blockchains, "thelonious", chainId, "0", "genesis.json"))
+		ifExit(err)
+		fmt.Println(string(b))
 	case "config":
-		ifExit(utils.Copy(path.Join(utils.Blockchains, "thelonious", "config.json"), "config.json"))
+		b, err := ioutil.ReadFile(path.Join(utils.Blockchains, "thelonious", chainId, "0", "config.json"))
+		ifExit(err)
+		fmt.Println(string(b))
 	case "chainid":
 		fmt.Println(chainId)
 	case "vars":
@@ -378,7 +382,7 @@ func cliAddRef(c *cli.Context) {
 		typ, id, err = chains.SplitRef(chain)
 
 		if err != nil {
-			exit(fmt.Errorf(`Error: specify the type in the first 
+			exit(fmt.Errorf(`Error: specify the type in the first
                 argument as '<type>/<chainId>'`))
 		}
 	}


### PR DESCRIPTION
This PR fixes something which has bugged me for a while. 

If `epm plop` is to be the machine readable display function then `epm plop genesis` should show me what the genesis.json is for the given chain. I understand, of course, that this was a change from what `epm plop` used to be. However, it is easy enough to actually make a file in the current directory which has the genesis.json components by simply `epm plop genesis > genesis.json`. 

This change would require more keystrokes for when a geneis.json in the `pwd` is desired, but for all other cases it will be more beneficial. For example, when working in containers we can have the start script plop both the genesis and the config so that what the container is doing will be highly visible in the container's logs. Also as plop is meant to be a quick display without accouterments (and because I often just want to see the genesis without `cat`-ing it and figuring out the chainId, etc.) this change would fit with that philosophy. 