### PR TITLE
ls keyfiles

### DIFF
--- a/cmd/epm/cli.go
+++ b/cmd/epm/cli.go
@@ -105,7 +105,13 @@ func cliRefs(c *cli.Context) {
 		keyname := m.Property("KeySession").(string)
 		var key []byte
 		key, err = ioutil.ReadFile(path.Join(chainDir, keyname+".addr"))
-		ifExit(err)
+		if err != nil {
+			if strings.Contains(keyname, "-") {
+				key = []byte(strings.Split(keyname, "-")[1])
+			} else {
+				ifExit(err)
+			}
+		}
 		if strings.Contains(rv, h) {
 			color.ChangeColor(color.Green, true, color.None, false)
 			fmt.Printf("%-20s%-60s%-20s\n", rk, rv, key)
@@ -763,6 +769,36 @@ func cliKeyImport(c *cli.Context) {
 		exit(fmt.Errorf("Please enter path to key to import"))
 	}
 	keyFile := c.Args()[0]
+	useKey(keyFile, c)
+}
+
+func cliKeyUse(c *cli.Context) {
+	if len(c.Args()) == 0 {
+		exit(fmt.Errorf("Please enter a key name to use."))
+	}
+	var keyFile string
+	keyName := c.Args()[0]
+	allKeys, err := filepath.Glob(path.Join(utils.Keys, keyName) + "*")
+	ifExit(err)
+	if (len(allKeys) > 1) {
+		var i int
+		fmt.Println("More than one key found with that name. Please select the proper one.")
+		for key := range allKeys {
+			fmt.Printf("%v.\t%s\n", (key+1), allKeys[key])
+		}
+		fmt.Printf(">>> ")
+		fmt.Scan(&i)
+		keyFile = allKeys[(i-1)]
+	} else if (len(allKeys) == 1) {
+		keyFile = allKeys[0]
+	} else {
+		exit(fmt.Errorf("No key found with that name."))
+	}
+	useKey(keyFile, c)
+}
+
+func useKey(keyFile string, c *cli.Context) {
+
 	name := path.Base(keyFile)
 
 	// set key in chain's config
@@ -782,8 +818,9 @@ func cliKeyImport(c *cli.Context) {
 		logger.Errorln(err)
 	}
 	m.WriteConfig(path.Join(root, "config.json"))
-	logger.Warnln("Done")
+	logger.Warnln("Using key")
 }
+
 
 func cliKeyExport(c *cli.Context) {
 	if len(c.Args()) == 0 {

--- a/cmd/epm/cli.go
+++ b/cmd/epm/cli.go
@@ -112,13 +112,30 @@ func cliRefs(c *cli.Context) {
 				ifExit(err)
 			}
 		}
+		kn := "0x" + string(key)
+		ifExit(err)
 		if strings.Contains(rv, h) {
 			color.ChangeColor(color.Green, true, color.None, false)
-			fmt.Printf("%-20s%-60s%-20s\n", rk, rv, key)
+			fmt.Printf("%-20s%-60s%-20s\n", rk, rv, kn)
 			color.ResetColor()
 		} else {
-			fmt.Printf("%-20s%-60s%-20s\n", rk, rv, key)
+			fmt.Printf("%-20s%-60s%-20s\n", rk, rv, kn)
 		}
+	}
+	exit(err)
+}
+
+// list the keyfiles
+func cliLsKeys(c *cli.Context) {
+	keys, err := ioutil.ReadDir(utils.Keys)
+	ifExit(err)
+	fmt.Printf("%-20s%-60s%-20s\n", "Name:", "Address:", "Key Value:")
+	for i := range keys {
+		k := strings.Split(keys[i].Name(), "-")
+		k[1] = "0x" + k[1]
+		kv, err := ioutil.ReadFile(path.Join(utils.Keys, keys[i].Name()))
+		ifExit(err)
+		fmt.Printf("%-20s%-60s%-20s\n", k[0], k[1], kv)
 	}
 	exit(err)
 }
@@ -780,16 +797,16 @@ func cliKeyUse(c *cli.Context) {
 	keyName := c.Args()[0]
 	allKeys, err := filepath.Glob(path.Join(utils.Keys, keyName) + "*")
 	ifExit(err)
-	if (len(allKeys) > 1) {
+	if len(allKeys) > 1 {
 		var i int
 		fmt.Println("More than one key found with that name. Please select the proper one.")
 		for key := range allKeys {
-			fmt.Printf("%v.\t%s\n", (key+1), allKeys[key])
+			fmt.Printf("%v.\t%s\n", (key + 1), allKeys[key])
 		}
 		fmt.Printf(">>> ")
 		fmt.Scan(&i)
-		keyFile = allKeys[(i-1)]
-	} else if (len(allKeys) == 1) {
+		keyFile = allKeys[(i - 1)]
+	} else if len(allKeys) == 1 {
 		keyFile = allKeys[0]
 	} else {
 		exit(fmt.Errorf("No key found with that name."))
@@ -820,7 +837,6 @@ func useKey(keyFile string, c *cli.Context) {
 	m.WriteConfig(path.Join(root, "config.json"))
 	logger.Warnln("Using key")
 }
-
 
 func cliKeyExport(c *cli.Context) {
 	if len(c.Args()) == 0 {

--- a/cmd/epm/commands.go
+++ b/cmd/epm/commands.go
@@ -231,6 +231,7 @@ var (
 		Subcommands: []cli.Command{
 			keygenCmd,
 			keyLsCmd,
+			keyUseCmd,
 			keyExportCmd,
 			keyImportCmd,
 		},
@@ -249,6 +250,12 @@ var (
 		Flags: []cli.Flag{
 			noImportFlag,
 		},
+	}
+
+	keyUseCmd = cli.Command{
+		Name: "use",
+		Usage: "use a particular key with the currently checked out blockchain",
+		Action: cliKeyUse,
 	}
 
 	keyExportCmd = cli.Command{

--- a/cmd/epm/commands.go
+++ b/cmd/epm/commands.go
@@ -227,7 +227,7 @@ var (
 	keysCmd = cli.Command{
 		Name:   "keys",
 		Usage:  "generate, import, and export keys for your blockchains",
-		Action: cliRefs,
+		Action: cliLsKeys,
 		Subcommands: []cli.Command{
 			keygenCmd,
 			keyLsCmd,
@@ -239,8 +239,8 @@ var (
 
 	keyLsCmd = cli.Command{
 		Name:   "ls",
-		Usage:  "list the blockchains and their asssociated key addresses",
-		Action: cliRefs,
+		Usage:  "list the keys and their associated names and addresses",
+		Action: cliLsKeys,
 	}
 
 	keygenCmd = cli.Command{
@@ -253,8 +253,8 @@ var (
 	}
 
 	keyUseCmd = cli.Command{
-		Name: "use",
-		Usage: "use a particular key with the currently checked out blockchain",
+		Name:   "use",
+		Usage:  "use a particular key with the currently checked out blockchain",
 		Action: cliKeyUse,
 	}
 


### PR DESCRIPTION
changes:

* `epm keys` defaults to showing the keyfiles in same format as `epm refs` only showing: Name, Address, and Key Value
* `epm refs` adds `0x` before the address for easy copying and pasting
