### PR TITLE
use a key by the string made from keys gen

### DIFF
--- a/cmd/epm/cli.go
+++ b/cmd/epm/cli.go
@@ -105,7 +105,13 @@ func cliRefs(c *cli.Context) {
 		keyname := m.Property("KeySession").(string)
 		var key []byte
 		key, err = ioutil.ReadFile(path.Join(chainDir, keyname+".addr"))
-		ifExit(err)
+		if err != nil {
+			if strings.Contains(keyname, "-") {
+				key = []byte(strings.Split(keyname, "-")[1])
+			} else {
+				ifExit(err)
+			}
+		}
 		if strings.Contains(rv, h) {
 			color.ChangeColor(color.Green, true, color.None, false)
 			fmt.Printf("%-20s%-60s%-20s\n", rk, rv, key)
@@ -763,6 +769,36 @@ func cliKeyImport(c *cli.Context) {
 		exit(fmt.Errorf("Please enter path to key to import"))
 	}
 	keyFile := c.Args()[0]
+	useKey(keyFile, c)
+}
+
+func cliKeyUse(c *cli.Context) {
+	if len(c.Args()) == 0 {
+		exit(fmt.Errorf("Please enter a key name to use."))
+	}
+	var keyFile string
+	keyName := c.Args()[0]
+	allKeys, err := filepath.Glob(path.Join(utils.Keys, keyName) + "*")
+	ifExit(err)
+	if (len(allKeys) > 1) {
+		var i int
+		fmt.Println("More than one key found with that name. Please select the proper one.")
+		for key := range allKeys {
+			fmt.Printf("%v.\t%s\n", (key+1), allKeys[key])
+		}
+		fmt.Printf(">>> ")
+		fmt.Scan(&i)
+		keyFile = allKeys[(i-1)]
+	} else if (len(allKeys) == 1) {
+		keyFile = allKeys[0]
+	} else {
+		exit(fmt.Errorf("No key found with that name."))
+	}
+	useKey(keyFile, c)
+}
+
+func useKey(keyFile string, c *cli.Context) {
+
 	name := path.Base(keyFile)
 
 	// set key in chain's config
@@ -782,8 +818,9 @@ func cliKeyImport(c *cli.Context) {
 		logger.Errorln(err)
 	}
 	m.WriteConfig(path.Join(root, "config.json"))
-	logger.Warnln("Done")
+	logger.Warnln("Using key")
 }
+
 
 func cliKeyExport(c *cli.Context) {
 	if len(c.Args()) == 0 {

--- a/cmd/epm/commands.go
+++ b/cmd/epm/commands.go
@@ -240,6 +240,7 @@ var (
 		Subcommands: []cli.Command{
 			keygenCmd,
 			keyLsCmd,
+			keyUseCmd,
 			keyExportCmd,
 			keyImportCmd,
 		},
@@ -258,6 +259,12 @@ var (
 		Flags: []cli.Flag{
 			noImportFlag,
 		},
+	}
+
+	keyUseCmd = cli.Command{
+		Name: "use",
+		Usage: "use a particular key with the currently checked out blockchain",
+		Action: cliKeyUse,
 	}
 
 	keyExportCmd = cli.Command{


### PR DESCRIPTION
changes:

* adds guard for when a key file is added to a chain but that chain has not been ran (and so no *.addr file has been dropped) 
* use key function added. usage `epm keygen casey && epm keys use casey` will generate a key with a name of casey and then add it to be used locally. 
* ensure nothing happens when no string matches post the glob of keys dir.
* when multiple keys exist with given string name, will display the matched keys and ask which key should be used.

It is a bit of a shortcut with import, so have DRY-ed up those two functions.
