### PR TITLE
no-new flag for dapp install without new chain. closes #86

### DIFF
--- a/cmd/epm/commands.go
+++ b/cmd/epm/commands.go
@@ -207,16 +207,6 @@ var (
 		},
 	}
 
-	testCmd = cli.Command{
-		Name:   "test",
-		Usage:  "run all pdx/pdt in the directory",
-		Action: cliTest,
-		Flags: []cli.Flag{
-			chainFlag,
-			contractPathFlag,
-		},
-	}
-
 	installCmd = cli.Command{
 		Name:   "install",
 		Usage:  "install a dapp into the decerver working tree and add a new blockchain with the same reference",
@@ -227,6 +217,7 @@ var (
 			nameFlag,
 			forceNameFlag,
 			editConfigFlag,
+			noNewChainFlag,
 		},
 	}
 
@@ -246,8 +237,8 @@ var (
 	}
 
 	keyLsCmd = cli.Command{
-		Name:	"ls",
-		Usage: "list the blockchains and their asssociated key addresses",
+		Name:   "ls",
+		Usage:  "list the blockchains and their asssociated key addresses",
 		Action: cliRefs,
 	}
 
@@ -272,5 +263,15 @@ var (
 		Usage:  "import a key file",
 		Action: cliKeyImport,
 		Flags:  []cli.Flag{},
+	}
+
+	testCmd = cli.Command{
+		Name:   "test",
+		Usage:  "run all pdx/pdt in the directory",
+		Action: cliTest,
+		Flags: []cli.Flag{
+			chainFlag,
+			contractPathFlag,
+		},
 	}
 )

--- a/cmd/epm/flags.go
+++ b/cmd/epm/flags.go
@@ -148,9 +148,9 @@ var (
 	}
 
 	pdxPathFlag = cli.StringFlag{
-		Name:  "p",
-		Value: ".",
-		Usage: "specify a .pdx file to deploy",
+		Name:   "p",
+		Value:  ".",
+		Usage:  "specify a .pdx file to deploy",
 		EnvVar: "DEPLOY_PDX",
 	}
 
@@ -235,5 +235,10 @@ var (
 	noImportFlag = cli.BoolFlag{
 		Name:  "no-import",
 		Usage: "stop epm from importing the generated key into chain's config",
+	}
+
+	noNewChainFlag = cli.BoolFlag{
+		Name:  "no-new",
+		Usage: "dont deploy a new chain for installation of the dapp",
 	}
 )


### PR DESCRIPTION
`epm install -no-new hello-world-dapp helloworld` to install dapp for the current checked out chain