### PR TITLE
fix ordering of help to maintain alphabetical

### DIFF
--- a/cmd/epm/main.go
+++ b/cmd/epm/main.go
@@ -43,6 +43,7 @@ func main() {
 	}
 
 	app.Commands = []cli.Command{
+		accountsCmd,
 		checkoutCmd,
 		cleanCmd,
 		commandCmd,
@@ -62,7 +63,6 @@ func main() {
 		runCmd,
 		runDappCmd,
 		testCmd,
-		accountsCmd,
 	}
 
 	run(app)


### PR DESCRIPTION
this PR moves new command `accounts` to its proper alphabetical location within the help commands.