### PR TITLE
fix containers and tests to compile; bolster start script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,36 @@
-# Dependencies
-
-## Make sure your machine has >= 1 GB of RAM.
-
-## Make sure go version >= 1.3.3 is installed and set up
 FROM golang:1.4
-MAINTAINER Eris Industries <contact@erisindustries.com>
+MAINTAINER Eris Industries <support@erisindustries.com>
 
-### The base image kills /var/lib/apt/lists/*.
-RUN apt-get update
-RUN apt-get install -y \
-  libgmp3-dev jq
+RUN apt-get update && \
+  apt-get install -y \
+  libgmp3-dev \
+  jq
 
-RUN mkdir --parents $GOPATH/src/github.com/eris-ltd
-WORKDIR $GOPATH/src/github.com/eris-ltd
+# Copy In the Good Stuff -- the branch checkout is temporary
+RUN git clone https://github.com/eris-ltd/eris-std-lib \
+  $GOPATH/src/github.com/eris-ltd/eris-std-lib && \
+  cd $GOPATH/src/github.com/eris-ltd/eris-std-lib && \
+  git checkout newepm
 
-RUN git clone https://github.com/eris-ltd/eris-std-lib
-RUN cd eris-std-lib && git checkout newepm # needed for new branch
+COPY . $GOPATH/src/github.com/eris-ltd/epm-go/
+RUN cd $GOPATH/src/github.com/eris-ltd/epm-go/cmd/epm && \
+  go install
 
-## Copy In the Good Stuff
-COPY . $GOPATH/src/github.com/eris-ltd/epm-go
-RUN cd epm-go
-COPY *.sh /
+# Set a user
+ENV user eris
+RUN groupadd --system $user && \
+  useradd --system --create-home --gid $user $user
+COPY *.sh /home/$user/
+RUN mkdir /home/$user/genesis/
 
+# User gets the perms (gopath chown necessary for tests)
+RUN chown --recursive $user /home/$user && \
+  chown --recursive $user $GOPATH/src/github.com/eris-ltd
+WORKDIR /home/$user
+USER $user
+RUN epm init
 
 ## How Does It Run?
-EXPOSE 15254 15255
-CMD ["/start.sh"]
+VOLUME /home/$user/.decerver/keys
+EXPOSE 15254 15255 15256
+CMD ["./start.sh"]

--- a/circle.yml
+++ b/circle.yml
@@ -4,9 +4,9 @@ machine:
 
 dependencies:
   override:
-    - sudo pip install -U fig
+    - sudo pip install -U docker-compose
 
 test:
   override:
-    - fig up --no-color --no-recreate > $CIRCLE_ARTIFACTS/output.log
+    - docker-compose up --no-color --no-recreate > $CIRCLE_ARTIFACTS/output.log
     - test -e /tmp/success

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 epmtest:
         build: .
-        volumes: 
+        volumes:
                 - /tmp:/opt
-        command: /test.sh
-        
+        command: ./test.sh
+

--- a/start.sh
+++ b/start.sh
@@ -1,33 +1,101 @@
 #!/bin/sh
 
+echo ""
+echo ""
 echo "Hello There! I'm your friendly blockchain container."
-echo ""
-echo "My GENESIS.JSON which you sent me is:"
-echo $GENESIS
-echo ""
-echo ""
-echo "I'm Starting to build the Chain. And setting local_vars."
-echo $GENESIS > /root/genesis.json
 key_session="$(strings /dev/urandom | grep -o '[[:alnum:]]' | head -n 10 | tr -d '\n' ; echo)"
 
-epm new --name ${CHAIN_NAME:=this_chain} --checkout --genesis /root/genesis.json
-epm config key_session:${KEY_SESSION:=key_session} \
+echo ""
+echo ""
+echo "Checking if Master"
+if [ "$MASTER" = "true" ]
+then
+  echo ""
+  echo ""
+  echo "I'm a master node so I will build a chain now."
+  echo ""
+  echo ""
+  if [ -z "$GENESIS" ]
+  then
+    echo "No GENESIS variable was given will try volume approach."
+    if [ -f /home/$user/genesis/genesis.json ]
+    then
+      echo "The GENESIS.JSON which you sent me is (the first 50 lines only...):"
+      head -n 50 /home/$user/genesis/genesis.json
+    else
+      echo "No GENESIS.JSON given, using default:"
+    fi
+    echo ""
+    echo ""
+  else
+    echo "The GENESIS.JSON which you sent me is:"
+    echo $GENESIS
+    echo $GENESIS > /home/$user/genesis/genesis.json
+    echo ""
+    echo ""
+  fi
+  if [ -f /home/$user/genesis/genesis.json ]
+  then
+    epm --log ${LOG_LEVEL:=3} new --name ${CHAIN_NAME:=this_chain} --checkout --genesis /home/$user/genesis/genesis.json
+  else
+    epm --log ${LOG_LEVEL:=3} new --name ${CHAIN_NAME:=this_chain} --checkout --no-edit
+  fi
+  epm config key_session:$key_session
+  epm run & sleep 3 && kill $(epm plop pid)
+  echo "The chain has been built and checked out."
+else
+  echo "I'm not a master."
+fi
+
+echo ""
+echo ""
+echo "Checking if Fetcher"
+if [ "$FETCH" = "true" ]
+then
+  echo "I'm supposed to fetch so I will grab the chain from $REMOTE_HOST:$REMOTE_FETCH_PORT."
+  echo ""
+  epm --log ${LOG_LEVEL:=3} fetch --checkout --name ${CHAIN_NAME:=this_chain} $REMOTE_HOST:$REMOTE_FETCH_PORT
+  echo ""
+  echo "Catching up the chain from $REMOTE_HOST:$REMOTE_PORT. This will take a few seconds."
+  echo ""
+  epm config key_session:$key_session remote_host:$REMOTE_HOST remote_port:$REMOTE_PORT use_seed:true
+  epm --log ${LOG_LEVEL:=3} run & sleep 30 && kill $(epm plop pid)
+  echo "The chain has been fetched and checked out."
+else
+  echo "I'm not a fetcher."
+fi
+
+echo ""
+echo ""
+echo "Setting Defaults"
+epm config key_session:$key_session \
   local_host:${LOCAL_HOST:=0.0.0.0} \
   local_port:${LOCAL_PORT:=15254} \
   max_peers:${MAX_PEERS:=10}
 
 echo ""
 echo ""
-echo "RPC Check."
-if [ "$RPC" = true ]
+echo "Setting the Key File"
+if [ -z "$KEY_FILE" ]
 then
-  epm config serve_rpc:true rpc_host:$RPC_HOST rpc_port:${RPC_PORT:=15255}
+  echo "No key file given."
+else
+  echo "Using the given key file."
+  epm keys use ${KEY_FILE}
+fi
+
+echo ""
+echo ""
+echo "RPC Check."
+if [ "$RPC" = "true" ]
+then
+  epm config serve_rpc:true rpc_host:${RPC_HOST:=0.0.0.0} rpc_port:${RPC_PORT:=15255}
 fi
 
 echo ""
 echo ""
 echo "Connect Check."
-if [ "$CONNECT" = true ]
+if [ "$CONNECT" = "true" ]
 then
   epm config remote_host:$REMOTE_HOST remote_port:$REMOTE_PORT use_seed:true
 fi
@@ -35,7 +103,7 @@ fi
 echo ""
 echo ""
 echo "SOLO Check."
-if [ "$SOLO" = true ]
+if [ "$SOLO" = "true" ]
 then
   epm config listen:false
 fi
@@ -43,12 +111,31 @@ fi
 echo ""
 echo ""
 echo "Mining Check."
-if [ "$MINING" = true ]
+if [ "$MINING" = "true" ]
 then
   epm config mining:true
 fi
 
 echo ""
 echo ""
+echo "Fetch Serve Check."
+if [ "$SERVE_GBLOCK" = "true" ]
+then
+  epm config fetch_port:${FETCH_PORT:=50505}
+fi
+
+echo ""
+echo ""
+echo "My CHAINID is ... ->"
+epm plop chainid
+CHAINID=$(epm plop chainid)
+
+echo ""
+echo ""
+echo "My Public Address is ... ->"
+epm plop addr
+
+echo ""
+echo ""
 echo "Starting up! (Wheeeeeee says the marmot)"
-epm --log ${LOG_LEVEL:=5} run
+exec epm --log ${LOG_LEVEL:=3} run

--- a/test.sh
+++ b/test.sh
@@ -3,14 +3,14 @@ set -e
 rm -f /tmp/success # in case its around
 
 # install epm
-cd $GOPATH/src/github.com/eris-ltd/epm-go/cmd/epm
-go install
+# cd $GOPATH/src/github.com/eris-ltd/epm-go/cmd/epm
+# go install
+# epm init
 
 cd $GOPATH/src/github.com/eris-ltd/epm-go
 
 # XXX: set develop lllc server
-export DECERVER=/.decerver
-epm init
+export DECERVER=/home/eris/.decerver
 echo `jq '.lll.url |= "http://ps.erisindustries.com:8092/compile"' $DECERVER/languages/config.json` > $DECERVER/languages/config.json
 echo `jq '.se.url |= "http://ps.erisindustries.com:8092/compile"' $DECERVER/languages/config.json` > $DECERVER/languages/config.json
 echo `jq '.sol.url |= "http://ps.erisindustries.com:8092/compile"' $DECERVER/languages/config.json` > $DECERVER/languages/config.json
@@ -37,6 +37,4 @@ epm --log 5 deploy test_solidity.pdx
 
 # fig up doesn't return proper error codes, so this is our hack
 touch /opt/success
-
-
 


### PR DESCRIPTION
fixes:

* rework dockerfile to use a $user rather than root
* rework dockerfile to copy rather than clone
* rework dockerfile to compile epm :package: within dockerfile rather than test script 
* rework dockerfile to move start and test scripts into user's home :honey_pot: 
* update from `fig` to `docker-compose` -> changes circle.yml and renames old fig.yml to reflect this :dragon: 
* start script now performs a three step check if it is to be a master node (1) is there an env var given of GENESIS, if so use that; (2) is there a mounted genesis.json file, if so use that; (3) if no env var or file given, just default
* start script now sets key_session before running chain
* start script now does a small boot sequence before setting most config vars to ensure all is working
* start script now runs post fetch to catch up change (will require a reversion of current fix in #107) 
* start script now defaults to log_level 3 as ping pongs too much
* start script now adds an `exec` call to the main `epm run` so that users can ctrl+c out of the running container if attached. 


