### PR TITLE
revert previous fix for #107

### DIFF
--- a/commands/cli.go
+++ b/commands/cli.go
@@ -270,11 +270,6 @@ func Fetch(c *Context) {
 
 	// update refs
 	updateRefs(chainType, chainID, c.String("force-name"), c.String("name"))
-
-	logger.Warnln("Ready to run chain...")
-	time.Sleep(time.Second * 2)
-	c.Strings["chain"] = "thelonious/" + chainID
-	Run(c)
 }
 
 // deploy the genblock into a random folder in scratch


### PR DESCRIPTION
Issue #107 should be rejected as it is much easier to handle
that process from a start script that it is from fetch.

In my experiences testing the implementation of #107 it was
apparent that we could not preset many of the values
(e.g., remote_peer_port ...). Much easier to keep having
`epm fetch` get the genesis block and then do a small
`epm run & sleep 20 && kill $(epm plop pid)` which gives
us much more flexibility when folks just run epm
from containers.